### PR TITLE
Add CORS middleware, config for accept fetching data from frontend (guweb)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ DATADOG_APP_KEY=
 
 DEBUG=False
 
+# cors config for fetching api from frontend
+CORS_ORIGINS=http://localhost:3000,https://cmyui.xyz
+
 # redirect beatmaps, beatmapsets, and forum
 # pages of maps to the official osu! website
 REDIRECT_OSU_URLS=True

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -9,9 +9,9 @@ from cmyui.logging import log
 from fastapi import FastAPI
 from fastapi import status
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.requests import Request
 from fastapi.responses import Response
-from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import RequestResponseEndpoint
 
 import app.bg_loops

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -11,6 +11,7 @@ from fastapi import status
 from fastapi.exceptions import RequestValidationError
 from fastapi.requests import Request
 from fastapi.responses import Response
+from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import RequestResponseEndpoint
 
 import app.bg_loops
@@ -59,6 +60,15 @@ def init_middlewares(asgi_app: FastAPI) -> None:
 
             # unrelated issue, raise normally
             raise exc
+
+    # cors middleware
+    asgi_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=app.settings.CORS_ORIGINS,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     asgi_app.add_middleware(middlewares.MetricsMiddleware)
 

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -64,7 +64,7 @@ def init_middlewares(asgi_app: FastAPI) -> None:
     # cors middleware
     asgi_app.add_middleware(
         CORSMiddleware,
-        allow_origins=app.settings.CORS_ORIGINS,
+        allow_origins=settings.CORS_ORIGINS,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/settings.py
+++ b/settings.py
@@ -45,6 +45,17 @@ DATADOG_APP_KEY: Secret = config("DATADOG_APP_KEY", cast=Secret)
 DEBUG: bool = config("DEBUG", cast=bool, default=False)
 REDIRECT_OSU_URLS: bool = config("REDIRECT_OSU_URLS", cast=bool, default=True)
 
+CORS_ORIGINS: CommaSeparatedStrings = config(
+    "CORS_ORIGINS",
+    cast=CommaSeparatedStrings,
+    default=",".join(
+        [
+            "http://localhost:3000",
+            "http://cmyui.xyz",
+        ],
+    ),
+)
+
 PP_CACHED_ACCS: list[int] = [
     int(acc)
     for acc in config(


### PR DESCRIPTION
for fixing `Access to XMLHttpRequest at 'https://domain/endpoint' from origin 'frontend_domain' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`